### PR TITLE
Add Laravel Boost support, PHP 8.5 NoDiscard, and test improvements

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,33 @@
+## Invoicing Interface Package
+
+This is a Laravel package (`indigitpt/invoicing-interface`) that provides a standardized API interface between a Laravel application and an external invoicing platform (e.g., Moloni). It handles document lifecycle management for payments, refunds, orders, and withdrawals.
+
+### Architecture
+
+- **Contract-based**: All document handlers must implement `DocumentInterface` — the consuming application provides concrete implementations.
+- **DTO-driven**: Uses `spatie/laravel-data` for type-safe data transfer objects. All DTOs live in `src/Data/`.
+- **Enum-routed**: `DocumentTypeEnum` drives routing — the main `Invoicing` class uses `match` expressions to dispatch to the correct handler.
+- **Bearer token auth**: API endpoints are protected via a custom `Authenticate` middleware that validates against `config('invoicing.api-key')`.
+
+### Conventions
+
+- PHP 8.5+ features should be used: pipe operator (`|>`), `clone()` with property overrides, `#[\NoDiscard]`, `array_first()`/`array_last()`.
+- All source classes use constructor property promotion.
+- Data classes extend `Spatie\LaravelData\Data` — do not use Eloquent models for data transfer.
+- The package uses `spatie/laravel-package-tools` for service provider scaffolding.
+- Tests use Pest PHP with architecture tests.
+- Static analysis runs at PHPStan level 8 with Larastan.
+- Code formatting uses Laravel Pint.
+
+### Key Patterns
+
+- The `Invoicing` class is the single entry point — it delegates to injected `DocumentInterface` implementations via constructor injection.
+- Routes are defined in `routes/api.php` with the prefix `invoicing-interface/api`.
+- Configuration is minimal: only an API key from the environment (`INVOICING_API_KEY`).
+
+### What NOT to Do
+
+- Do not add Eloquent models — this package is a transport/interface layer.
+- Do not hardcode invoicing provider logic — implementations belong in the consuming application.
+- Do not bypass the `DocumentInterface` contract for new document types.
+- Do not add complex middleware chains — authentication is intentionally simple (bearer token).

--- a/resources/boost/skills/invoicing-development/SKILL.md
+++ b/resources/boost/skills/invoicing-development/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: invoicing-development
+description: Build and extend the invoicing interface package, including adding document types, creating DTOs, implementing handlers, and working with the API.
+---
+
+# Invoicing Interface Development
+
+## When to use this skill
+
+Use this skill when:
+- Adding a new document type to the invoicing interface
+- Creating or modifying Data Transfer Objects (DTOs)
+- Implementing the `DocumentInterface` contract
+- Working with the invoicing API routes
+- Writing tests for invoicing functionality
+
+## Package Structure
+
+```
+src/
+├── Invoicing.php                    # Main service (entry point)
+├── InvoicingServiceProvider.php     # Package registration
+├── Contracts/
+│   └── DocumentInterface.php        # Contract for document handlers
+├── Enums/
+│   └── DocumentTypeEnum.php         # Document type routing enum
+├── Http/Middleware/
+│   └── Authenticate.php             # Bearer token auth
+└── Data/                            # DTOs (Spatie Laravel Data)
+    ├── CustomerData.php
+    ├── OrderData.php
+    ├── OrderPaymentData.php
+    ├── PaymentData.php
+    ├── PaymentProductData.php
+    ├── RefundData.php
+    └── UpdateDocumentReferencesData.php
+```
+
+## Adding a New Document Type
+
+1. Add a case to `DocumentTypeEnum`:
+
+```php
+enum DocumentTypeEnum: string
+{
+    use EnumConcern;
+
+    case Payment = 'payment';
+    case Refund = 'refund';
+    case Order = 'order';
+    case Withdrawal = 'withdrawal';
+    case NewType = 'new_type'; // Add here
+}
+```
+
+2. Add a constructor parameter and match arms in `Invoicing.php`:
+
+```php
+public function __construct(
+    protected Contracts\DocumentInterface $payments,
+    protected Contracts\DocumentInterface $refunds,
+    protected Contracts\DocumentInterface $orders,
+    protected Contracts\DocumentInterface $withdrawals,
+    protected Contracts\DocumentInterface $newTypes, // Add here
+) {}
+```
+
+3. Create a corresponding DTO in `src/Data/` extending `Spatie\LaravelData\Data`.
+
+4. Add tests covering pagination and update for the new type.
+
+## Creating a DTO
+
+DTOs extend `Spatie\LaravelData\Data` and use constructor property promotion:
+
+```php
+<?php
+
+namespace Indigit\Invoicing\Data;
+
+use Spatie\LaravelData\Data;
+
+class ExampleData extends Data
+{
+    public function __construct(
+        public string $reference_website,
+        public float $amount,
+        public ?string $optional_field = null,
+    ) {}
+}
+```
+
+For dates, use the `WithCast` attribute:
+
+```php
+use Illuminate\Support\Carbon;
+use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
+
+#[WithCast(DateTimeInterfaceCast::class)]
+public ?Carbon $paid_at = null,
+```
+
+For collections of nested DTOs, use PHPDoc generics:
+
+```php
+/** @var Collection<int, PaymentProductData> */
+public Collection $products,
+```
+
+## Implementing DocumentInterface
+
+The consuming application must provide implementations:
+
+```php
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Support\Collection;
+use Indigit\Invoicing\Contracts\DocumentInterface;
+use Indigit\Invoicing\Data\UpdateDocumentReferencesData;
+
+class PaymentDocumentHandler implements DocumentInterface
+{
+    public function paginate(int $perPage): Paginator
+    {
+        return Payment::query()->simplePaginate($perPage);
+    }
+
+    /** @param Collection<int, UpdateDocumentReferencesData> $data */
+    public function update(Collection $data): bool
+    {
+        // Update document references in your database
+        $data->each(function (UpdateDocumentReferencesData $item) {
+            Payment::where('id', $item->reference_website)
+                ->update([
+                    'financial_document_id' => $item->reference_financial_document,
+                    'provider_id' => $item->reference_provider,
+                    'document_label' => $item->document_label,
+                    'document_link' => $item->document_link,
+                ]);
+        });
+
+        return true;
+    }
+}
+```
+
+## Testing Patterns
+
+Tests use Pest PHP with a `DocumentHandler` test double:
+
+```php
+use Illuminate\Pagination\Paginator;
+use Indigit\Invoicing\Data\UpdateDocumentReferencesData;
+use Indigit\Invoicing\Enums\DocumentTypeEnum;
+use Indigit\Invoicing\Invoicing;
+use Indigit\Invoicing\Tests\TestSupport\DocumentHandler;
+
+beforeEach(function (): void {
+    $this->handler = new DocumentHandler;
+    $this->invoicing = new Invoicing(
+        $this->handler, // payments
+        $this->handler, // refunds
+        $this->handler, // orders
+        $this->handler, // withdrawals
+    );
+});
+
+it('can paginate documents', function (): void {
+    $this->handler->data = new Paginator(['doc1'], 10, 1);
+
+    $result = $this->invoicing->paginate(DocumentTypeEnum::Payment);
+    expect($result)->toBeInstanceOf(Paginator::class)
+        ->and($result->count())->toBe(1);
+});
+```

--- a/src/Contracts/DocumentInterface.php
+++ b/src/Contracts/DocumentInterface.php
@@ -11,6 +11,7 @@ interface DocumentInterface
     /**
      * Paginates documents
      */
+    #[\NoDiscard('Paginator result must be returned to the client')]
     public function paginate(int $perPage): Paginator;
 
     /**
@@ -18,5 +19,6 @@ interface DocumentInterface
      *
      * @param  Collection<int, UpdateDocumentReferencesData>  $data
      */
+    #[\NoDiscard('Update result must be checked for success/failure')]
     public function update(Collection $data): bool;
 }

--- a/src/Invoicing.php
+++ b/src/Invoicing.php
@@ -20,6 +20,7 @@ final class Invoicing
     /**
      * Paginates documents
      */
+    #[\NoDiscard('Paginator result must be returned to the client')]
     public function paginate(DocumentTypeEnum $type, ?int $perPage = null): Paginator
     {
         $perPage ??= 50;
@@ -37,6 +38,7 @@ final class Invoicing
      *
      * @param  Collection<int, UpdateDocumentReferencesData>  $data
      */
+    #[\NoDiscard('Response must be returned to the client')]
     public function update(DocumentTypeEnum $type, Collection $data): JsonResponse
     {
         $result = match ($type) {

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,5 +1,5 @@
 <?php
 
-// it('will not use debugging functions')
-//    ->expect(['dd', 'dump', 'ray'])
-//    ->each->not->toBeUsed();
+it('will not use debugging functions')
+    ->expect(['dd', 'dump', 'ray'])
+    ->each->not->toBeUsed();

--- a/tests/TestSupport/DocumentHandler.php
+++ b/tests/TestSupport/DocumentHandler.php
@@ -12,13 +12,21 @@ class DocumentHandler implements DocumentInterface
 
     public bool $updateResult = false;
 
+    public ?int $lastPerPage = null;
+
+    public ?Collection $lastUpdateData = null;
+
     public function paginate(int $perPage): Paginator
     {
+        $this->lastPerPage = $perPage;
+
         return $this->data;
     }
 
     public function update(Collection $data): bool
     {
+        $this->lastUpdateData = $data;
+
         return $this->updateResult;
     }
 }

--- a/tests/Unit/AuthenticateTest.php
+++ b/tests/Unit/AuthenticateTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Pagination\Paginator;
+use Indigit\Invoicing\Tests\TestSupport\DocumentHandler;
+
+beforeEach(function (): void {
+    $handler = new DocumentHandler;
+    $handler->data = new Paginator([], 50, 1);
+    $handler->updateResult = true;
+
+    $this->app->when(\Indigit\Invoicing\Invoicing::class)
+        ->needs(\Indigit\Invoicing\Contracts\DocumentInterface::class)
+        ->give(fn () => $handler);
+});
+
+it('returns 401 when no api key is configured', function (): void {
+    config()->set('invoicing.api-key', null);
+
+    $this->getJson('/invoicing-interface/api/payment')
+        ->assertStatus(401);
+});
+
+it('returns 403 when bearer token is invalid', function (): void {
+    config()->set('invoicing.api-key', 'valid-key');
+
+    $this->getJson('/invoicing-interface/api/payment', [
+        'Authorization' => 'Bearer wrong-key',
+    ])->assertStatus(403);
+});
+
+it('returns 403 when no bearer token is provided', function (): void {
+    config()->set('invoicing.api-key', 'valid-key');
+
+    $this->getJson('/invoicing-interface/api/payment')
+        ->assertStatus(403);
+});
+
+it('allows access with valid bearer token', function (): void {
+    config()->set('invoicing.api-key', 'valid-key');
+
+    $this->getJson('/invoicing-interface/api/payment', [
+        'Authorization' => 'Bearer valid-key',
+    ])->assertStatus(200);
+});
+
+it('returns 404 for invalid document type', function (): void {
+    config()->set('invoicing.api-key', 'valid-key');
+
+    $this->getJson('/invoicing-interface/api/invalid', [
+        'Authorization' => 'Bearer valid-key',
+    ])->assertStatus(404);
+});

--- a/tests/Unit/AuthenticateTest.php
+++ b/tests/Unit/AuthenticateTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Pagination\Paginator;
+use Indigit\Invoicing\Contracts\DocumentInterface;
+use Indigit\Invoicing\Invoicing;
 use Indigit\Invoicing\Tests\TestSupport\DocumentHandler;
 
 beforeEach(function (): void {
@@ -8,8 +10,8 @@ beforeEach(function (): void {
     $handler->data = new Paginator([], 50, 1);
     $handler->updateResult = true;
 
-    $this->app->when(\Indigit\Invoicing\Invoicing::class)
-        ->needs(\Indigit\Invoicing\Contracts\DocumentInterface::class)
+    $this->app->when(Invoicing::class)
+        ->needs(DocumentInterface::class)
         ->give(fn () => $handler);
 });
 

--- a/tests/Unit/InvoicingTest.php
+++ b/tests/Unit/InvoicingTest.php
@@ -9,14 +9,14 @@ use Indigit\Invoicing\Tests\TestSupport\DocumentHandler;
 
 beforeEach(function (): void {
     $this->paymentDocuments = new DocumentHandler;
-    $this->invoiceDocuments = new DocumentHandler;
     $this->refundDocuments = new DocumentHandler;
+    $this->orderDocuments = new DocumentHandler;
     $this->withdrawalDocuments = new DocumentHandler;
 
     $this->invoicing = new Invoicing(
         $this->paymentDocuments,
         $this->refundDocuments,
-        $this->invoiceDocuments,
+        $this->orderDocuments,
         $this->withdrawalDocuments
     );
 });
@@ -39,7 +39,7 @@ it('can paginate refunds', function (): void {
 });
 
 it('can paginate orders', function (): void {
-    $this->invoiceDocuments->data = new Paginator(['order1', 'order2', 'order3'], 10, 1);
+    $this->orderDocuments->data = new Paginator(['order1', 'order2', 'order3'], 10, 1);
 
     $result = $this->invoicing->paginate(DocumentTypeEnum::Order);
     expect($result)->toBeInstanceOf(Paginator::class)
@@ -56,13 +56,31 @@ it('can paginate withdrawals', function (): void {
         ->and($result->items())->toBe(['withdrawal1', 'withdrawal2', 'withdrawal3']);
 });
 
+it('uses default perPage of 50', function (): void {
+    $this->paymentDocuments->data = new Paginator([], 50, 1);
+
+    $result = $this->invoicing->paginate(DocumentTypeEnum::Payment);
+    expect($result)->toBeInstanceOf(Paginator::class)
+        ->and($this->paymentDocuments->lastPerPage)->toBe(50);
+});
+
+it('uses custom perPage when provided', function (): void {
+    $this->paymentDocuments->data = new Paginator([], 25, 1);
+
+    $result = $this->invoicing->paginate(DocumentTypeEnum::Payment, 25);
+    expect($result)->toBeInstanceOf(Paginator::class)
+        ->and($this->paymentDocuments->lastPerPage)->toBe(25);
+});
+
 it('can update payment identifier', function (): void {
     $updateData = collect([new UpdateDocumentReferencesData('payment123', 'external456')]);
     $this->paymentDocuments->updateResult = true;
 
     $result = $this->invoicing->update(DocumentTypeEnum::Payment, $updateData);
     expect($result)->toBeInstanceOf(JsonResponse::class)
-        ->and($result->getData()->status)->toBe('ok');
+        ->and($result->getData()->status)->toBe('ok')
+        ->and($result->getStatusCode())->toBe(200)
+        ->and($this->paymentDocuments->lastUpdateData)->toBe($updateData);
 });
 
 it('can update refund identifier', function (): void {
@@ -71,23 +89,69 @@ it('can update refund identifier', function (): void {
 
     $result = $this->invoicing->update(DocumentTypeEnum::Refund, $updateData);
     expect($result)->toBeInstanceOf(JsonResponse::class)
-        ->and($result->getData()->status)->toBe('ok');
+        ->and($result->getData()->status)->toBe('ok')
+        ->and($result->getStatusCode())->toBe(200)
+        ->and($this->refundDocuments->lastUpdateData)->toBe($updateData);
 });
 
-it('handles failed invoice identifier update', function (): void {
-    $updateData = collect([new UpdateDocumentReferencesData('invoice555', 'external999')]);
-    $this->invoiceDocuments->updateResult = false;
+it('can update order identifier', function (): void {
+    $updateData = collect([new UpdateDocumentReferencesData('order123', 'external789')]);
+    $this->orderDocuments->updateResult = true;
 
     $result = $this->invoicing->update(DocumentTypeEnum::Order, $updateData);
     expect($result)->toBeInstanceOf(JsonResponse::class)
-        ->and($result->getData()->status)->toBe('failed');
+        ->and($result->getData()->status)->toBe('ok')
+        ->and($result->getStatusCode())->toBe(200)
+        ->and($this->orderDocuments->lastUpdateData)->toBe($updateData);
+});
+
+it('can update withdrawal identifier', function (): void {
+    $updateData = collect([new UpdateDocumentReferencesData('withdrawal123', 'external789')]);
+    $this->withdrawalDocuments->updateResult = true;
+
+    $result = $this->invoicing->update(DocumentTypeEnum::Withdrawal, $updateData);
+    expect($result)->toBeInstanceOf(JsonResponse::class)
+        ->and($result->getData()->status)->toBe('ok')
+        ->and($result->getStatusCode())->toBe(200)
+        ->and($this->withdrawalDocuments->lastUpdateData)->toBe($updateData);
+});
+
+it('handles failed payment identifier update', function (): void {
+    $updateData = collect([new UpdateDocumentReferencesData('payment555', 'external999')]);
+    $this->paymentDocuments->updateResult = false;
+
+    $result = $this->invoicing->update(DocumentTypeEnum::Payment, $updateData);
+    expect($result)->toBeInstanceOf(JsonResponse::class)
+        ->and($result->getData()->status)->toBe('failed')
+        ->and($result->getStatusCode())->toBe(404);
+});
+
+it('handles failed refund identifier update', function (): void {
+    $updateData = collect([new UpdateDocumentReferencesData('refund555', 'external999')]);
+    $this->refundDocuments->updateResult = false;
+
+    $result = $this->invoicing->update(DocumentTypeEnum::Refund, $updateData);
+    expect($result)->toBeInstanceOf(JsonResponse::class)
+        ->and($result->getData()->status)->toBe('failed')
+        ->and($result->getStatusCode())->toBe(404);
+});
+
+it('handles failed order identifier update', function (): void {
+    $updateData = collect([new UpdateDocumentReferencesData('order555', 'external999')]);
+    $this->orderDocuments->updateResult = false;
+
+    $result = $this->invoicing->update(DocumentTypeEnum::Order, $updateData);
+    expect($result)->toBeInstanceOf(JsonResponse::class)
+        ->and($result->getData()->status)->toBe('failed')
+        ->and($result->getStatusCode())->toBe(404);
 });
 
 it('handles failed withdrawal identifier update', function (): void {
     $updateData = collect([new UpdateDocumentReferencesData('withdrawal555', 'external999')]);
-    $this->invoiceDocuments->updateResult = false;
+    $this->withdrawalDocuments->updateResult = false;
 
     $result = $this->invoicing->update(DocumentTypeEnum::Withdrawal, $updateData);
     expect($result)->toBeInstanceOf(JsonResponse::class)
-        ->and($result->getData()->status)->toBe('failed');
+        ->and($result->getData()->status)->toBe('failed')
+        ->and($result->getStatusCode())->toBe(404);
 });


### PR DESCRIPTION
## Summary

- Add Laravel Boost guidelines (`resources/boost/guidelines/core.blade.php`) and skills (`resources/boost/skills/invoicing-development/SKILL.md`) for AI-assisted development
- Add `#[\NoDiscard]` PHP 8.5 attributes to `DocumentInterface` and `Invoicing` methods to enforce return value usage
- Fix test bugs: rename `invoiceDocuments` to `orderDocuments`, fix wrong handler references in failure tests
- Expand test coverage from 8 to 20 tests (51 assertions): add perPage, status codes, data passthrough, and HTTP auth tests
- Enable architecture test for debug function detection

## Test plan

- [x] All 20 Pest tests pass (51 assertions)
- [x] PHPStan level 8 passes with no errors
- [x] Laravel Pint code style passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)